### PR TITLE
Build android apks using --split-per-abi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: build
-on: push
+on:
+  push:
+  workflow_dispatch:
 jobs:
   android:
     runs-on: ubuntu-latest
@@ -12,15 +14,23 @@ jobs:
           channel: stable
       - run: flutter pub get
       - run: flutter build appbundle
-      - run: flutter build apk
+      - run: flutter build apk --split-per-abi
       - uses: actions/upload-artifact@v4
         with:
           name: "freeflow_release.aab"
           path: "build/app/outputs/bundle/release/app-release.aab"
       - uses: actions/upload-artifact@v4
         with:
-          name: "freeflow_release.apk"
-          path: "build/app/outputs/flutter-apk/app-release.apk"
+          name: "freeflow_release-arm64-v8a.apk"
+          path: "build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "freeflow_release-armeabi-v7a.apk"
+          path: "build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: "freeflow_release-x86_64.apk"
+          path: "build/app/outputs/flutter-apk/app-x86_64-release.apk"
   ios:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: build
 on:
   push:
-  workflow_dispatch:
 jobs:
   android:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When building an universal .apk the file size is ~65MB, and when building separate abi for specific architecture the file size is ~25MB.