### PR TITLE
Refactor to use ndk accounts usecase

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,15 +55,19 @@ Future<void> main() async {
   // reload / cache login data
   l.addListener(() {
     if (l.value != null) {
-      switch (l.value!.type) {
-        case AccountType.privateKey:
-          ndk.accounts.loginPrivateKey(pubkey: l.value!.pubkey, privkey: l.value!.privateKey!);
-        case AccountType.externalSigner:
-          ndk.accounts.loginExternalSigner(
-              signer: AmberEventSigner(publicKey: l.value!.pubkey, amberFlutterDS: AmberFlutterDS(Amberflutter()))
-          );
-        case AccountType.publicKey:
-          ndk.accounts.loginPublicKey(pubkey: l.value!.pubkey);
+      if (!ndk.accounts.hasAccount(l.value!.pubkey)) {
+        switch (l.value!.type) {
+          case AccountType.privateKey:
+            ndk.accounts.loginPrivateKey(
+                pubkey: l.value!.pubkey, privkey: l.value!.privateKey!);
+          case AccountType.externalSigner:
+            ndk.accounts.loginExternalSigner(
+                signer: AmberEventSigner(publicKey: l.value!.pubkey,
+                    amberFlutterDS: AmberFlutterDS(Amberflutter()))
+            );
+          case AccountType.publicKey:
+            ndk.accounts.loginPublicKey(pubkey: l.value!.pubkey);
+        }
       }
       ndk.metadata.loadMetadata(l.value!.pubkey);
       ndk.follows.getContactList(l.value!.pubkey);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:amberflutter/amberflutter.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:freeflow/data/video.dart';
@@ -17,6 +18,8 @@ import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:ndk/ndk.dart';
 import 'package:ndk/shared/nips/nip19/nip19.dart';
+import 'package:ndk_amber/data_layer/data_sources/amber_flutter.dart';
+import 'package:ndk_amber/data_layer/repositories/signers/amber_event_signer.dart';
 import 'package:ndk_objectbox/ndk_objectbox.dart';
 import 'package:ndk_rust_verifier/data_layer/repositories/verifiers/rust_event_verifier.dart';
 
@@ -52,13 +55,16 @@ Future<void> main() async {
   // reload / cache login data
   l.addListener(() {
     if (l.value != null) {
-      ndk = Ndk(
-        NdkConfig(
-            cache: ndk_cache,
-            eventVerifier: eventVerifier,
-            eventSigner: l.value!.signer(),
-            bootstrapRelays: DEFAULT_RELAYS),
-      );
+      switch (l.value!.type) {
+        case AccountType.privateKey:
+          ndk.accounts.loginPrivateKey(pubkey: l.value!.pubkey, privkey: l.value!.privateKey!);
+        case AccountType.externalSigner:
+          ndk.accounts.loginExternalSigner(
+              signer: AmberEventSigner(publicKey: l.value!.pubkey, amberFlutterDS: AmberFlutterDS(Amberflutter()))
+          );
+        case AccountType.publicKey:
+          ndk.accounts.loginPublicKey(pubkey: l.value!.pubkey);
+      }
       ndk.metadata.loadMetadata(l.value!.pubkey);
       ndk.follows.getContactList(l.value!.pubkey);
     }

--- a/lib/screens/new_account.dart
+++ b/lib/screens/new_account.dart
@@ -5,7 +5,8 @@ import 'package:freeflow/widgets/button.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:ndk/entities.dart';
+import 'package:ndk/config/bootstrap_relays.dart';
+import 'package:ndk/domain_layer/entities/metadata.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/shared/nips/nip01/key_pair.dart';
 
@@ -76,6 +77,8 @@ class _NewAccountScreen extends State<NewAccountScreen> {
   }
 
   Future<void> _uploadAvatar() async {
+    ndk.accounts.loginPrivateKey(pubkey: _privateKey.publicKey, privkey: _privateKey.privateKey!);
+
     final file = await ImagePicker().pickImage(source: ImageSource.gallery);
     if (file != null) {
       final upload =
@@ -87,31 +90,16 @@ class _NewAccountScreen extends State<NewAccountScreen> {
   }
 
   Future<void> _login() async {
-    final meta = Metadata(
+    if (ndk.accounts.isNotLoggedIn) {
+      ndk.accounts.loginPrivateKey(
+          pubkey: _privateKey.publicKey, privkey: _privateKey.privateKey!);
+    }
+
+    ndk.metadata.broadcastMetadata(Metadata(
       pubKey: _privateKey.publicKey,
       name: _name.text,
       picture: _avatar,
-    );
-
-    final profile = meta.toEvent();
-    profile.sign(_privateKey.privateKey!);
-
-    final relays = Nip65.fromMap(
-      _privateKey.publicKey,
-      Map.fromEntries(
-        DEFAULT_RELAYS.map(
-          (r) => MapEntry(r, ReadWriteMarker.readWrite),
-        ),
-      ),
-    );
-    final relayEvent = relays.toEvent();
-    relayEvent.sign(_privateKey.privateKey!);
-
-    await ndk.userRelayLists
-        .setInitialUserRelayList(UserRelayList.fromNip65(relays));
-    await ndk.broadcast.broadcast(
-      nostrEvent: profile,
-      specificRelays: DEFAULT_RELAYS,
-    );
+    ),
+    specificRelays: DEFAULT_BOOTSTRAP_RELAYS);
   }
 }

--- a/lib/screens/new_account.dart
+++ b/lib/screens/new_account.dart
@@ -95,11 +95,10 @@ class _NewAccountScreen extends State<NewAccountScreen> {
           pubkey: _privateKey.publicKey, privkey: _privateKey.privateKey!);
     }
 
-    ndk.metadata.broadcastMetadata(Metadata(
+    await ndk.metadata.broadcastMetadata(Metadata(
       pubKey: _privateKey.publicKey,
       name: _name.text,
       picture: _avatar,
-    ),
-    specificRelays: DEFAULT_BOOTSTRAP_RELAYS);
+    ));
   }
 }

--- a/lib/view_model/login.dart
+++ b/lib/view_model/login.dart
@@ -1,15 +1,10 @@
 import 'dart:convert';
 
-import 'package:amberflutter/amberflutter.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:ndk/ndk.dart';
+import 'package:ndk/domain_layer/entities/account.dart';
 import 'package:ndk/shared/nips/nip01/bip340.dart';
 import 'package:ndk/shared/nips/nip19/nip19.dart';
-import 'package:ndk_amber/data_layer/data_sources/amber_flutter.dart';
-import 'package:ndk_amber/data_layer/repositories/signers/amber_event_signer.dart';
-
-enum AccountType { Keys, ExternalSigner }
 
 class Account {
   final AccountType type;
@@ -25,19 +20,19 @@ class Account {
         Nip19.isKey("nsec", key) ? Bip340.getPublicKey(keyData) : keyData;
     final privateKey = Nip19.isKey("npub", key) ? null : keyData;
     return Account._(
-        type: AccountType.Keys, pubkey: pubkey, privateKey: privateKey);
+        type: AccountType.privateKey, pubkey: pubkey, privateKey: privateKey);
   }
 
   static Account privateKeyHex(String key) {
     return Account._(
-        type: AccountType.Keys,
+        type: AccountType.privateKey,
         privateKey: key,
         pubkey: Bip340.getPublicKey(key));
   }
 
   static Account externalPublicKeyHex(String key) {
     return Account._(
-        type: AccountType.ExternalSigner,
+        type: AccountType.externalSigner,
         pubkey: key);
   }
 
@@ -50,22 +45,11 @@ class Account {
   static Account? fromJson(Map<String, dynamic> json) {
     if (json.length > 2 && json.containsKey("pubKey")) {
       return Account._(
-          type: AccountType.Keys,
+          type: AccountType.privateKey,
           pubkey: json["pubKey"],
           privateKey: json["privateKey"]);
     }
     return null;
-  }
-
-  EventSigner signer() {
-    switch (type) {
-      case AccountType.Keys:
-        return Bip340EventSigner(privateKey: privateKey, publicKey: pubkey);
-      case AccountType.ExternalSigner:
-        return AmberEventSigner(publicKey: pubkey, amberFlutterDS: AmberFlutterDS(Amberflutter()));
-    }
-    // ignore: dead_code
-    throw UnimplementedError();
   }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   get_it: ^8.0.3
   cached_network_image: ^3.4.1
   ndk: ^0.2.6
-  ndk_objectbox: ^0.2.0
+  ndk_objectbox: ^0.2.1
   ndk_amber: 0.2.0
   amberflutter: ^0.0.9
   ndk_rust_verifier: ^0.2.2
@@ -31,6 +31,13 @@ dependencies:
     git:
       url: https://github.com/nostrlabs-io/VideoCompress.git
       rev: a8123f2054d28b32b84a2ba0601fdcfe78b581b2
+
+dependency_overrides:
+  ndk:
+    git:
+      url: https://github.com/relaystr/ndk
+      path: packages/ndk
+      ref: 43cb4340195e2edd75bdec5ea21862b582a1fb4e
 
 dev_dependencies:
   flutter_launcher_icons: "^0.14.3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,7 @@ dependency_overrides:
     git:
       url: https://github.com/relaystr/ndk
       path: packages/ndk
-      ref: 43cb4340195e2edd75bdec5ea21862b582a1fb4e
+      ref: cc404d7f0773de850eb9f22990f2b13d28d7f97e
 
 dev_dependencies:
   flutter_launcher_icons: "^0.14.3"


### PR DESCRIPTION
No need to replace full ndk anymore to have signer replaced.
Using `ndk.accounts` usecase will manage the signers for multi-accounts.
Supported `privateKey`, `publicKey` (read-only) and `externalSigner` types.

Related https://github.com/relaystr/ndk/issues/106